### PR TITLE
Add FrontendType while context is typed on backend

### DIFF
--- a/examples/typescript/client/index.ts
+++ b/examples/typescript/client/index.ts
@@ -2,12 +2,16 @@ import "babel-polyfill";
 import { Server } from "../endpoints";
 import { server as serverUntyped } from "@wildcard-api/client";
 
-export const server: Server = serverUntyped;
+export const server = serverUntyped as Server;
 
 (async () => {
   const id = Math.floor(Math.random() * 3);
   const person = await server.getPerson(id);
-  const personHtml =
-    person.firstName + " " + person.lastName + " <b>(" + person.id + ")</b>";
-  document.body.innerHTML = personHtml;
+  if (person === null) {
+    document.body.innerHTML = "Could not retrieve person";
+  } else {
+    const personHtml =
+      person.firstName + " " + person.lastName + " <b>(" + person.id + ")</b>";
+    document.body.innerHTML = personHtml;
+  }
 })();

--- a/examples/typescript/client/index.ts
+++ b/examples/typescript/client/index.ts
@@ -2,7 +2,7 @@ import "babel-polyfill";
 import { Server } from "../endpoints";
 import { server as serverUntyped } from "@wildcard-api/client";
 
-export const server = serverUntyped as Server;
+const server = serverUntyped as Server;
 
 (async () => {
   const id = Math.floor(Math.random() * 3);

--- a/examples/typescript/context.ts
+++ b/examples/typescript/context.ts
@@ -1,0 +1,3 @@
+export type Context = {
+  isLoggedIn: boolean;
+};

--- a/examples/typescript/endpoints.ts
+++ b/examples/typescript/endpoints.ts
@@ -1,4 +1,4 @@
-import { server as _server, ServerGeneric } from "@wildcard-api/server";
+import { server as _server, FrontendType } from "@wildcard-api/server";
 import { Context } from "./context";
 
 interface Person {
@@ -21,6 +21,6 @@ async function getPerson(this: Context, id: number): Promise<Person | null> {
 const server = {
   getPerson,
 };
-export type Server = ServerGeneric<typeof server, Context>;
+export type Server = FrontendType<typeof server, Context>;
 
 Object.assign(_server, server);

--- a/examples/typescript/endpoints.ts
+++ b/examples/typescript/endpoints.ts
@@ -15,7 +15,7 @@ const persons: Array<Person> = [
 
 async function getPerson(this: Context, id: number): Promise<Person | null> {
   if (!this.isLoggedIn) return null;
-  return persons.find((person) => person.id === id);
+  return persons.find((person) => person.id === id) || null;
 }
 
 const server = {

--- a/examples/typescript/endpoints.ts
+++ b/examples/typescript/endpoints.ts
@@ -13,7 +13,7 @@ const persons: Array<Person> = [
   { firstName: "Harry", lastName: "Thompson", id: 2 },
 ];
 
-async function getPerson(this: Context, id: number): Promise<Person | null> {
+async function getPerson(this: Context, id: number) {
   if (!this.isLoggedIn) return null;
   return persons.find((person) => person.id === id) || null;
 }

--- a/examples/typescript/endpoints.ts
+++ b/examples/typescript/endpoints.ts
@@ -1,4 +1,4 @@
-import { server as _server, FrontendType } from "@wildcard-api/server";
+import { server as _server, ServerGeneric } from "@wildcard-api/server";
 import { Context } from "./context";
 
 interface Person {
@@ -21,6 +21,6 @@ async function getPerson(this: Context, id: number): Promise<Person | null> {
 const server = {
   getPerson,
 };
-export type Server = FrontendType<typeof server, Context>;
+export type Server = ServerGeneric<typeof server, Context>;
 
 Object.assign(_server, server);

--- a/examples/typescript/endpoints.ts
+++ b/examples/typescript/endpoints.ts
@@ -1,4 +1,5 @@
-import { server as _server } from "@wildcard-api/server";
+import { server as _server, FrontendType } from "@wildcard-api/server";
+import { Context } from "./context";
 
 interface Person {
   firstName: string;
@@ -12,13 +13,14 @@ const persons: Array<Person> = [
   { firstName: "Harry", lastName: "Thompson", id: 2 },
 ];
 
-async function getPerson(id: number): Promise<Person> {
+async function getPerson(this: Context, id: number): Promise<Person | null> {
+  if (!this.isLoggedIn) return null;
   return persons.find((person) => person.id === id);
 }
 
 const server = {
   getPerson,
 };
-export type Server = typeof server;
+export type Server = FrontendType<typeof server, Context>;
 
 Object.assign(_server, server);

--- a/examples/typescript/start-server.ts
+++ b/examples/typescript/start-server.ts
@@ -1,14 +1,14 @@
 import express from "express";
 import { wildcard } from "@wildcard-api/server/express";
 import "./endpoints.ts";
+import { Context } from "./context";
 
 const app = express();
 
 // Server our API endpoints
 app.use(
-  wildcard(async (req) => {
-    const { headers } = req;
-    const context = { headers };
+  wildcard(() => {
+    const context: Context = { isLoggedIn: true };
     return context;
   })
 );

--- a/examples/typescript/tsconfig.json
+++ b/examples/typescript/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "strict": true,
     "esModuleInterop": true
   }
 }

--- a/server/WildcardServer.ts
+++ b/server/WildcardServer.ts
@@ -69,12 +69,18 @@ export type HttpResponseProps = {
   etag?: HttpResponseEtag;
 };
 
-type MinusContext<T, C> = T extends (this: C, ...rest: infer U) => infer R
-  ? (...rest: U) => R
+type MinusContext<EndpointFunction, Context> = EndpointFunction extends (
+  this: Context,
+  ...rest: infer EndpointArguments
+) => infer EndpointReturnType
+  ? (...rest: EndpointArguments) => EndpointReturnType
   : never;
 
-export type FrontendType<T, C> = {
-  [F in keyof T]: MinusContext<T[F], C>;
+export type ServerGeneric<Endpoints, Context> = {
+  [EndpointName in keyof Endpoints]: MinusContext<
+    Endpoints[EndpointName],
+    Context
+  >;
 };
 
 // Whether to call the endpoint:

--- a/server/WildcardServer.ts
+++ b/server/WildcardServer.ts
@@ -69,6 +69,14 @@ export type HttpResponseProps = {
   etag?: HttpResponseEtag;
 };
 
+type MinusContext<T, C> = T extends (this: C, ...rest: infer U) => infer R
+  ? (...rest: U) => R
+  : never;
+
+export type FrontendType<T, C> = {
+  [F in keyof T]: MinusContext<T[F], C>;
+};
+
 // Whether to call the endpoint:
 // 1. over HTTP (browser-side <-> Node.js communication) or
 // 2. directly (communication whithin a single Node.js process, e.g. when doing SSR).

--- a/server/WildcardServer.ts
+++ b/server/WildcardServer.ts
@@ -76,7 +76,7 @@ type MinusContext<EndpointFunction, Context> = EndpointFunction extends (
   ? (...rest: EndpointArguments) => EndpointReturnType
   : never;
 
-export type ServerGeneric<Endpoints, Context> = {
+export type FrontendType<Endpoints, Context> = {
   [EndpointName in keyof Endpoints]: MinusContext<
     Endpoints[EndpointName],
     Context

--- a/server/index.ts
+++ b/server/index.ts
@@ -2,4 +2,4 @@ import { wildcardServer } from "./global-instance";
 export const server = wildcardServer.endpoints;
 export const { config } = wildcardServer;
 export const { getApiHttpResponse } = wildcardServer;
-export { FrontendType } from "./WildcardServer";
+export { ServerGeneric } from "./WildcardServer";

--- a/server/index.ts
+++ b/server/index.ts
@@ -2,4 +2,4 @@ import { wildcardServer } from "./global-instance";
 export const server = wildcardServer.endpoints;
 export const { config } = wildcardServer;
 export const { getApiHttpResponse } = wildcardServer;
-export { ServerGeneric } from "./WildcardServer";
+export { FrontendType } from "./WildcardServer";

--- a/server/index.ts
+++ b/server/index.ts
@@ -2,3 +2,4 @@ import { wildcardServer } from "./global-instance";
 export const server = wildcardServer.endpoints;
 export const { config } = wildcardServer;
 export const { getApiHttpResponse } = wildcardServer;
+export { FrontendType } from "./WildcardServer";


### PR DESCRIPTION
Resolves #51

- [x] How to name the type? `FrontendType`, `ClientType`?
- [x] Why is the return type of `getPerson` `Promise<Person>` and not `Promise<Person | null>`, while typescript is also not complaining about dead code when we compare it to `null`?
- [x] Handle functions that are not using `this` and are therefore not being typed.
- [x] Write docs

Not done in this PR:
- How to write a test for this?
- Prevent casting https://github.com/reframejs/wildcard-api/pull/58#discussion_r505507215